### PR TITLE
Fix bug in order of scaling for individual components

### DIFF
--- a/src/light_curve_comp.cc
+++ b/src/light_curve_comp.cc
@@ -345,6 +345,15 @@ void Lcurve::light_curve_comp(const Lcurve::Model& mdl,
 
       wdwarf *= sfac[0];
       if(mdl.iscale){
+          // sfac is not in the same order as fcomp
+          Subs::Buffer1D<double> tfac(4);
+          tfac = sfac;
+          sfac.resize(5);
+          sfac[0] = tfac[0]; // white dwarf
+          sfac[1] = tfac[2]; // disc
+          sfac[2] = tfac[2]; // disc edge
+          sfac[3] = tfac[3]; // spot   
+          sfac[4] = tfac[1]; // donor
           for(size_t np=0; np<data.size(); np++){
               calc[np] = sfac[0]*fcomp[np][0]+sfac[1]*fcomp[np][1]+
                   sfac[2]*fcomp[np][2]+sfac[3]*fcomp[np][3];


### PR DESCRIPTION
When calculating the final output lightcurve, `lroche` has several options for how to scale the individual components (disc, primary, secondary, etc):

1. `model.iscale = false`
In this case all the components brightness are set by their temperatures and the whole lightcurve is scaled to fit the data. If `autoscale` is set, then this scaling is found automatically, if not it is given by the user.

2. `model.iscale = false`
In this case the brightness of each individual component is found post-hoc, and the temperatures are ignored for this purpose. If `autoscale` is set, each component is scaled individually to fit the data. Otherwise the scaling of each component is prompted for by the user.

It is this latter case that is broken, as the order of the scaling factors `sfac` has, over time, become uncoupled from the order of the various components `fcomp`. This PR fixes this issue. 